### PR TITLE
Revert range provider scheme from '*' to 'file'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,13 +20,13 @@ function setup(context: vscode.ExtensionContext) { // {{{
 		if(name === '*') {
 			provider = new FoldingProvider(config[name]);
 
-			subscriptions.push(disposable = vscode.languages.registerFoldingRangeProvider({ scheme: '*' }, provider));
+			subscriptions.push(disposable = vscode.languages.registerFoldingRangeProvider({ scheme: 'file' }, provider));
 			context.subscriptions.push(disposable);
 		}
 		else {
 			provider = new FoldingProvider(config[name]);
 
-			subscriptions.push(disposable = vscode.languages.registerFoldingRangeProvider({ language: name, scheme: '*' }, provider));
+			subscriptions.push(disposable = vscode.languages.registerFoldingRangeProvider({ language: name, scheme: 'file' }, provider));
 			context.subscriptions.push(disposable);
 		}
 	}


### PR DESCRIPTION
fix #30 

In v0.9.1 the scheme was switched to '*' from 'file which is
preventing the extension from being picked up in some situations.
This change switches it back to 'file'.

See https://github.com/zokugun/vscode-explicit-folding/issues/30

@daiyam this change fixes the issue for me but I have done zero testing on other platforms and know nothing about why scheme was switched to '*' in the first place, so unsure if this will break things for others.