### PR TITLE
feat: add variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,27 @@ So you can auto fold only the imports with:
 
 [enum values](https://github.com/zokugun/vscode-explicit-folding/blob/master/docs/properties/auto-fold.md)
 
+Variables
+---------
+
+```jsonc
+{
+    "variables": {
+        "BeginComment1": "\\/\\*",
+        "EndComment1": "\\*\\/",
+    },
+},
+{
+    "beginRegex": "{{!BeginComment1}}",
+    "endRegex": "{{!EndComment1}}",
+},
+```
+
+| property  | `{{:varname}}` (escape) | `{{!varname}}` (raw) |
+| --------- | :---------------------: | :------------------: |
+| non-regex |           ✅            |         ☠️         |
+| regex     |           ✅            |          ✅          |
+
 Debugging
 ---------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
 			"license": "MIT",
 			"dependencies": {
 				"@daiyam/regexp": "^0.2.1",
-				"@zokugun/vscode.explicit-folding-api": "0.2.1",
+				"@zokugun/vscode.explicit-folding-api": "0.3.0",
+				"@zokugun/xtry": "^0.1.0",
 				"minimatch": "^5.1.0"
 			},
 			"devDependencies": {
@@ -1964,12 +1965,19 @@
 			"peer": true
 		},
 		"node_modules/@zokugun/vscode.explicit-folding-api": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@zokugun/vscode.explicit-folding-api/-/vscode.explicit-folding-api-0.2.1.tgz",
-			"integrity": "sha512-fkSTo7M9rjVUaqwr46dhig91m8N85hEh19+yoT4DVHVE+BFcCY58GAlaIFMBzfXW7RuaWOXU1y1YKLXAFJVUzw==",
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@zokugun/vscode.explicit-folding-api/-/vscode.explicit-folding-api-0.3.0.tgz",
+			"integrity": "sha512-oOWSJeVnukeomb3Ks+fbhXW3nGPvg1o3FHhVHeGqvVrrtDrLb1X4on+h6bBbBwjYl8NcNCj+CKvL+IChg3XgqA==",
+			"license": "MIT",
 			"engines": {
 				"vscode": "^1.23.0"
 			}
+		},
+		"node_modules/@zokugun/xtry": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@zokugun/xtry/-/xtry-0.1.0.tgz",
+			"integrity": "sha512-rj/wpYaKhvWprVt1ZextW9isY56SEb+Y5bvpBTm/sfISA5Xvs9DoaEI272rplym57sYQhPHrvf0dYNb/TplTQg==",
+			"license": "MIT"
 		},
 		"node_modules/acorn": {
 			"version": "8.14.1",
@@ -13877,9 +13885,14 @@
 			"peer": true
 		},
 		"@zokugun/vscode.explicit-folding-api": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@zokugun/vscode.explicit-folding-api/-/vscode.explicit-folding-api-0.2.1.tgz",
-			"integrity": "sha512-fkSTo7M9rjVUaqwr46dhig91m8N85hEh19+yoT4DVHVE+BFcCY58GAlaIFMBzfXW7RuaWOXU1y1YKLXAFJVUzw=="
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@zokugun/vscode.explicit-folding-api/-/vscode.explicit-folding-api-0.3.0.tgz",
+			"integrity": "sha512-oOWSJeVnukeomb3Ks+fbhXW3nGPvg1o3FHhVHeGqvVrrtDrLb1X4on+h6bBbBwjYl8NcNCj+CKvL+IChg3XgqA=="
+		},
+		"@zokugun/xtry": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@zokugun/xtry/-/xtry-0.1.0.tgz",
+			"integrity": "sha512-rj/wpYaKhvWprVt1ZextW9isY56SEb+Y5bvpBTm/sfISA5Xvs9DoaEI272rplym57sYQhPHrvf0dYNb/TplTQg=="
 		},
 		"acorn": {
 			"version": "8.14.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
 	},
 	"dependencies": {
 		"@daiyam/regexp": "^0.2.1",
-		"@zokugun/vscode.explicit-folding-api": "0.2.1",
+		"@zokugun/vscode.explicit-folding-api": "0.3.0",
+		"@zokugun/xtry": "^0.1.0",
 		"minimatch": "^5.1.0"
 	},
 	"devDependencies": {

--- a/src/folding-hub.ts
+++ b/src/folding-hub.ts
@@ -1,14 +1,14 @@
-import type { ExplicitFoldingConfig, ExplicitFoldingHub } from '@zokugun/vscode.explicit-folding-api';
+import type API from '@zokugun/vscode.explicit-folding-api';
 
-export class FoldingHub implements ExplicitFoldingHub {
-	private perLanguages: Record<string, ExplicitFoldingConfig[] | undefined> = {};
+export class FoldingHub implements API.Hub {
+	private perLanguages: Record<string, API.Config[] | undefined> = {};
 	private readonly setup: () => void;
 
 	constructor(setup: () => void) {
 		this.setup = setup;
 	}
 
-	getRules(language: string): ExplicitFoldingConfig[] | undefined {
+	getRules(language: string): API.Config[] | undefined {
 		return this.perLanguages[language];
 	}
 
@@ -16,7 +16,7 @@ export class FoldingHub implements ExplicitFoldingHub {
 		return this.perLanguages[language] !== undefined;
 	}
 
-	registerFoldingRules(language: string, rules: ExplicitFoldingConfig[]): void {
+	registerFoldingRules(language: string, rules: API.Config[]): void {
 		this.perLanguages[language] = rules;
 
 		this.setup();

--- a/src/folding-provider.test.ts
+++ b/src/folding-provider.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { type ExplicitFoldingConfig } from '@zokugun/vscode.explicit-folding-api';
+import type API from '@zokugun/vscode.explicit-folding-api';
 import { expect } from 'chai';
 import klaw from 'klaw-sync';
 import { FoldingRangeKind } from 'vscode';
@@ -28,7 +28,7 @@ describe('fold', () => {
 		const name = path.basename(file).slice(0, path.basename(file).lastIndexOf('.'));
 
 		it(`${language}.${name}`, () => {
-			const { config, foldings } = YAML.parse(fs.readFileSync(path.join(path.dirname(file), `${name}.yml`), 'utf8')) as { config: ExplicitFoldingConfig[]; foldings: Range[] };
+			const { config, foldings } = YAML.parse(fs.readFileSync(path.join(path.dirname(file), `${name}.yml`), 'utf8')) as { config: API.Config[]; foldings: Range[] };
 
 			const provider = new FoldingProvider(config, undefined, []);
 

--- a/src/route-provider.ts
+++ b/src/route-provider.ts
@@ -1,5 +1,5 @@
 import { basename } from 'path';
-import type { ExplicitFoldingConfig } from '@zokugun/vscode.explicit-folding-api';
+import type API from '@zokugun/vscode.explicit-folding-api';
 import { type IMinimatch, Minimatch } from 'minimatch';
 import type { FoldingRange, FoldingRangeProvider, OutputChannel, ProviderResult, TextDocument } from 'vscode';
 import { FoldingProvider } from './folding-provider.js';
@@ -17,7 +17,7 @@ export class RouteProvider implements FoldingRangeProvider {
 	private readonly mainProvider: FoldingProvider;
 	private readonly routes: Route[] = [];
 
-	constructor(perFiles: Record<string, ExplicitFoldingConfig[] | ExplicitFoldingConfig | undefined>, mainProvider: FoldingProvider, debugChannel: OutputChannel | undefined, documents: TextDocument[], langRules: Record<string, ExplicitFoldingConfig[]>) { // {{{
+	constructor(perFiles: Record<string, API.Config[] | API.Config | undefined>, mainProvider: FoldingProvider, debugChannel: OutputChannel | undefined, documents: TextDocument[], langRules: Record<string, API.Config[]>) { // {{{
 		this.mainProvider = mainProvider;
 		this.debugChannel = debugChannel;
 
@@ -57,11 +57,14 @@ export class RouteProvider implements FoldingRangeProvider {
 		return this.mainProvider.provideFoldingRanges(document);
 	} // }}}
 
-	protected applyRules(rawRules: ExplicitFoldingConfig[], langRules: Record<string, ExplicitFoldingConfig[]>): ExplicitFoldingConfig[] { // {{{
-		const rules: ExplicitFoldingConfig[] = [];
+	protected applyRules(rawRules: API.Config[], langRules: Record<string, API.Config[]>): API.Config[] { // {{{
+		const rules: API.Config[] = [];
 
 		for(const rule of rawRules) {
-			if(rule.include) {
+			if(rule.variables) {
+				rules.push(rule);
+			}
+			else if(rule.include) {
 				if(Array.isArray(rule.include)) {
 					for(const lang of rule.include) {
 						rules.push(...langRules[lang]);


### PR DESCRIPTION
References:
- #126

```jsonc
{
    "variables": {
        "BeginComment1": "\\/\\*",
        "EndComment1": "\\*\\/",
    },
},
{
    "beginRegex": "{{!BeginComment1}}",
    "endRegex": "{{!EndComment1}}",
},
```

- `{{:varname}}`: the replacement is escaped
- `{{!varname}}`: the replacement is raw (only available for regex properties)