### PR TITLE
Fix/multi root uri config

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,6 +152,8 @@ async function buildRules() { // {{{
 	const config = vscode.workspace.getConfiguration(CONFIG_KEY, referenceUri);
 	const debug = config.get<boolean>('debug') ?? false;
 	const channel = getDebugChannel(debug);
+	channel?.appendLine(`[config] referenceUri: ${referenceUri?.fsPath ?? 'null'}`);
+	channel?.appendLine(`[config] activeDocumentUri: ${vscode.window.activeTextEditor?.document?.uri.fsPath ?? 'null'}`);
 	const dependencies: Record<string, Array<{ language: string; index: number }>> = {};
 
 	const globalRules = config.get<Record<string, ExplicitFoldingConfig | ExplicitFoldingConfig[]>>('rules') ?? {};
@@ -319,6 +321,9 @@ function setupProvidersWithProxy(): void { // {{{
 function setupProvidersWithoutProxy(): void { // {{{
 	const referenceUri = getReferenceUri();
 	const config = vscode.workspace.getConfiguration(CONFIG_KEY, referenceUri);
+	const debug = config.get<boolean>('debug') ?? false;
+	const channel = getDebugChannel(debug);
+	channel?.appendLine(`[config] setupProvidersWithoutProxy referenceUri: ${referenceUri?.fsPath ?? 'null'}`);
 	const wildcardExclusions = Array.isArray(config.wildcardExclusions) ? config.wildcardExclusions : [];
 
 	void vscode.languages.getLanguages().then((languages) => {
@@ -326,6 +331,7 @@ function setupProvidersWithoutProxy(): void { // {{{
 			if(!wildcardExclusions.includes(language)) {
 				const langScope = referenceUri ? { languageId: language, uri: referenceUri } : { languageId: language };
 				const config = vscode.workspace.getConfiguration(CONFIG_KEY, langScope);
+				channel?.appendLine(`[config] languageScope: ${language}, uri: ${referenceUri?.fsPath ?? 'null'}`);
 				const mainProvider = buildProvider(language, config);
 
 				const perFiles = config.get<Record<string, ExplicitFoldingConfig[] | ExplicitFoldingConfig | undefined> | undefined>('perFiles');


### PR DESCRIPTION
Fixes #151
## Summary
Resolve explicit-folding configuration with a concrete URI scope so language-specific reads include workspace-folder settings in multi-root workspaces.
## What changed
- Added `getReferenceUri()` helper (active editor URI, fallback first workspace folder URI)
- In `buildRules()`:
  - use `getConfiguration(CONFIG_KEY, referenceUri)`
  - use language scope `{ languageId, uri: referenceUri }`
- In `setupProvidersWithoutProxy()`:
  - use URI-scoped base config
  - use language scope `{ languageId, uri: referenceUri }`
## Additional debug enhancement
- Added debug lines that print full paths for:
  - resolved `referenceUri`
  - active document URI
  - per-language scope URI
## Why
In multi-root setups, folder-level `explicitFolding.rules` could exist but be ignored during language-scoped resolution, causing:
- `[main] regex: /a^/`
- empty foldings
## Test plan
- Reproduced in multi-root workspace (`palm_development` + `Poisson`)
- Verified `/a^/` before fix
- Verified compiled regex + non-empty foldings after fix